### PR TITLE
Arreglar el botón de borrar de books/show, que borraba una nota en vez del libro

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -27,13 +27,13 @@
           title: 'Edit book', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom') do %>
         <i class="fas fa-pencil-alt"></i>
       <%end%>
-      <%= link_to(note_path, method: :delete,
+      <%= link_to(book_path(@book), method: :delete,
           data: { confirm: 'Are you sure? This will delete all notes from this book and cannot be undone!' },
           class:"btn btn-sm btn-outline-danger",
           title: 'Delete book', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom') do %>
         <i class="far fa-trash-alt"></i>
       <%end%>
-      <%= link_to(download_all_notes_from_book_path, class:"btn btn-sm btn-outline-primary", 
+      <%= link_to(download_all_notes_from_book_path(@book), class:"btn btn-sm btn-outline-primary",
           title:"Download ALL notes from this book in ONE file.") do %>
         <i class="fas fa-download"></i>
       <%end%>

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -35,6 +35,16 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # Regresión: el botón de borrar apuntaba a `note_path` (sin argumento), que
+  # tomaba el :id del request y armaba /notes/:id, así que borraba una nota en
+  # vez del libro.
+  test "show links the delete button to the book, not to a note" do
+    get book_url(@book)
+
+    destroy_links = css_select("a[data-method='delete']").map { |a| a["href"] }
+    assert_includes destroy_links, book_path(@book)
+  end
+
   test "should update book" do
     patch book_url(@book), params: { book: { is_default: @book.is_default, name: @book.name, user_id: @book.user_id } }
     assert_redirected_to book_url(@book)

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -42,6 +42,16 @@ class BooksTest < ApplicationSystemTestCase
     assert_selector "h1", text: "Nombre actualizado"
   end
 
+  test "destroying a Book from its show page" do
+    visit book_url(@book)
+
+    accept_confirm { find("a[href='#{book_path(@book)}'][data-method='delete']").click }
+
+    assert_text "Book was successfully destroyed"
+    assert_selector "h1", text: "Books"
+    assert_nil Book.find_by(id: @book.id)
+  end
+
   test "destroying a Book" do
     visit books_url
 


### PR DESCRIPTION
Apilado sobre #73. La base es `chore/upgrade-ruby-3.2-rails-7.2`, no `master`,
porque en master la app no arranca (Ruby 2.7.2, gemas sin instalar) y no se
podrían correr los tests. Al mergear #73 primero, este queda apuntando a
master solo.

## El bug

En `app/views/books/show.html.erb` el botón "Delete book" usaba `note_path`
**sin argumento**. Sin argumento el helper completa el segmento `:id` con el
del request actual, así que en `/books/42` generaba `DELETE /notes/42`.

Confirmado sobre la app corriendo: en `/books/980190962` el botón renderiza
`href="/notes/980190962"`.

### Consecuencias

- El libro **nunca se borraba**: desde su propia página no había forma de
  eliminarlo.
- Si el usuario tenía una nota cuyo id coincidía con el del libro, **esa nota
  se borraba en silencio**, detrás de un confirm que decía "This will delete
  all notes from this book".
- Si no existía tal nota, `current_user.notes.find` levantaba
  `RecordNotFound` y respondía 404.

No hay fuga entre usuarios: `set_note` ya filtra por `current_user.notes`.

## El arreglo

Apunta a `book_path(@book)`. De paso se le pasa `@book` explícito a
`download_all_notes_from_book_path`, que venía andando por el mismo mecanismo
implícito pero por casualidad: ahí el `:id` del request sí era el del libro.

## Tests

Dos de regresión, **ambos verificados en rojo sin el arreglo**:

- controlador: el href renderizado apunta a `/books/:id`.
- sistema: borra el libro desde su página y comprueba que efectivamente
  desaparece.

Suite completa: 19 unitarios + 9 de sistema, 0 failures.
