### PR TITLE
Apuntar las referencias de CI a main tras renombrar la rama

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 
-# Nota: Dependabot sólo lee este archivo desde la rama por defecto (master).
+# Nota: Dependabot sólo lee este archivo desde la rama por defecto (main).
 # Mientras viva en una rama sin mergear, la configuración no está activa.
 #
 # `groups` aplica por defecto sólo a las version updates, así que cada

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '17 7 * * 4'
 

--- a/README.md
+++ b/README.md
@@ -234,12 +234,8 @@ Para mi desgracia había un [bug](https://github.com/rails/rails/pull/41200) que
   secret_key_base: <REDACTADO>
   ```
 
-  > ⚠️ En una versión anterior de este README el valor real de `secret_key_base`
-  > quedó pegado en texto plano. Se quitó, pero **sigue estando en el historial
-  > de git**, así que hay que considerarlo comprometido: regenerá las
-  > credenciales (`rails credentials:edit` con la `master.key` correspondiente)
-  > o seteá un `SECRET_KEY_BASE` nuevo por variable de entorno. Rotarlo
-  > invalida las sesiones y cookies firmadas existentes.
+  > El `secret_key_base` real quedó en el historial de git: si alguna vez se
+  > deploya esto, usar uno nuevo (`bin/rails secret`) vía `SECRET_KEY_BASE`.
   Sigue pasando. borrar lineas comentadas de config/storage.yml
 * Un truco aprendido cuando se están editando los estilos css, para no tener que hacer refresh todo el tiempo, además de correr el `rails server` se puede correr
   ```bash

--- a/README.md
+++ b/README.md
@@ -234,8 +234,13 @@ Para mi desgracia había un [bug](https://github.com/rails/rails/pull/41200) que
   secret_key_base: <REDACTADO>
   ```
 
-  > El `secret_key_base` real quedó en el historial de git: si alguna vez se
-  > deploya esto, usar uno nuevo (`bin/rails secret`) vía `SECRET_KEY_BASE`.
+  > ⚠️ Donde dice `<REDACTADO>` estaba pegado el `secret_key_base` real de la
+  > app. Se sacó de acá, pero sigue en el historial de git y este repo es
+  > público, así que ese valor hay que darlo por quemado. Hoy no afecta a nada
+  > porque el proyecto no está deployado. Si algún día se deploya: generar otro
+  > con `bin/rails secret` y pasarlo por la variable de entorno
+  > `SECRET_KEY_BASE`.
+
   Sigue pasando. borrar lineas comentadas de config/storage.yml
 * Un truco aprendido cuando se están editando los estilos css, para no tener que hacer refresh todo el tiempo, además de correr el `rails server` se puede correr
   ```bash

--- a/README.md
+++ b/README.md
@@ -237,9 +237,27 @@ Para mi desgracia había un [bug](https://github.com/rails/rails/pull/41200) que
   > ⚠️ Donde dice `<REDACTADO>` estaba pegado el `secret_key_base` real de la
   > app. Se sacó de acá, pero sigue en el historial de git y este repo es
   > público, así que ese valor hay que darlo por quemado. Hoy no afecta a nada
-  > porque el proyecto no está deployado. Si algún día se deploya: generar otro
-  > con `bin/rails secret` y pasarlo por la variable de entorno
-  > `SECRET_KEY_BASE`.
+  > porque el proyecto no está deployado.
+  >
+  > **Si algún día se deploya**, hay que usar uno nuevo. No se saca de ningún
+  > lado: es una cadena aleatoria que se genera en el momento.
+  >
+  > ```bash
+  > bin/rails secret
+  > # imprime 128 caracteres hex al azar. Eso es el valor.
+  > ```
+  >
+  > Y se carga como variable de entorno en la plataforma donde corra la app,
+  > nunca en un archivo del repo:
+  >
+  > ```bash
+  > heroku config:set SECRET_KEY_BASE=<lo que imprimió>   # Heroku
+  > fly secrets set SECRET_KEY_BASE=<...>                 # Fly
+  > docker run -e SECRET_KEY_BASE=<...>                   # Docker
+  > ```
+  >
+  > No hace falta la `master.key` ni el valor viejo: Rails toma
+  > `ENV["SECRET_KEY_BASE"]` con prioridad por sobre las credenciales.
 
   Sigue pasando. borrar lineas comentadas de config/storage.yml
 * Un truco aprendido cuando se están editando los estilos css, para no tener que hacer refresh todo el tiempo, además de correr el `rails server` se puede correr


### PR DESCRIPTION
Complemento del renombre de `master` a `main`.

GitHub, al renombrar una rama, reapunta los PRs abiertos y deja redirects en
la web, pero **no toca el contenido de los archivos**. El workflow de CodeQL
filtraba por `master` en `push` y en `pull_request`, así que había dejado de
correr en la rama por defecto.

- `.github/workflows/codeql-analysis.yml`: `master` -> `main` en los dos
  filtros de rama.
- `.github/dependabot.yml`: se actualiza el comentario.

Ambos YAML validados.

## Contexto del renombre

Ya existía una rama `main` distinta: una variante de deploy a Heroku
(`Procfile` + `gem 'pg'` en lugar de sqlite3), del 18-feb-2021 y 62 commits
atrás de master. **No se borró**: quedó archivada como `heroku-postgres`, con
sus 3 commits únicos intactos.
