### PR TITLE
Correr los tests y la auditoría de dependencias en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Toma la versión de .ruby-version, así no hay que mantenerla en dos lugares.
+          ruby-version-file: .ruby-version
+          bundler-cache: true
+
+      - name: Instalar Node
+        uses: actions/setup-node@v4
+        with:
+          # setup-node sabe leer la línea `nodejs` de .tool-versions.
+          node-version-file: .tool-versions
+          cache: yarn
+
+      - name: Instalar dependencias de JS
+        run: yarn install --frozen-lockfile
+
+      - name: Preparar la base
+        run: bin/rails db:prepare
+
+      - name: Tests unitarios
+        run: bin/rails test
+
+      - name: Tests de sistema
+        # Corren en headless_chrome, que ya viene instalado en el runner.
+        run: bin/rails test:system
+
+      - name: Guardar capturas de los tests de sistema que fallaron
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: tmp/screenshots/
+          if-no-files-found: ignore
+
+  audit:
+    name: Auditoría de dependencias
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version-file: .ruby-version
+          bundler-cache: true
+
+      - name: Instalar Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+          cache: yarn
+
+      - name: Gemas con vulnerabilidades conocidas
+        run: bundle exec bundler-audit check --update
+
+      - name: Paquetes npm con vulnerabilidades conocidas
+        run: |
+          # yarn 1 no devuelve 0/1 sino un bitmask de severidades:
+          #   1 INFO | 2 LOW | 4 MODERATE | 8 HIGH | 16 CRITICAL
+          # y `--level` sólo filtra lo que imprime, no el exit code. Por eso hay
+          # que mirar los bits de HIGH (8) y CRITICAL (16) a mano.
+          #
+          # Se ignora moderate a propósito: summernote no tiene parche upstream,
+          # entra por admin-lte y la app nunca lo importa, así que no llega al
+          # bundle. Fallar por eso dejaría el build en rojo para siempre.
+          yarn audit || EXIT=$?
+          if [ $(( ${EXIT:-0} & 24 )) -ne 0 ]; then
+            echo "::error::Hay vulnerabilidades high o critical en el árbol de npm"
+            exit 1
+          fi
+          echo "Sin vulnerabilidades high ni critical"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,17 +75,34 @@ jobs:
 
       - name: Paquetes npm con vulnerabilidades conocidas
         run: |
-          # yarn 1 no devuelve 0/1 sino un bitmask de severidades:
-          #   1 INFO | 2 LOW | 4 MODERATE | 8 HIGH | 16 CRITICAL
-          # y `--level` sólo filtra lo que imprime, no el exit code. Por eso hay
-          # que mirar los bits de HIGH (8) y CRITICAL (16) a mano.
+          # No se mira el exit code de `yarn audit`: yarn 1 devuelve un bitmask
+          # de severidades (1 INFO | 2 LOW | 4 MODERATE | 8 HIGH | 16 CRITICAL),
+          # y un fallo real del comando (registry caído, sin red) también sale
+          # con 1. O sea que "no pude auditar" es indistinguible de "encontré
+          # avisos informativos", y el paso se pondría verde sin haber auditado.
           #
+          # En su lugar se parsea `--json` y se exige el registro `auditSummary`,
+          # que yarn sólo emite si la auditoría se completó.
+          yarn audit --json > audit.jsonl || true
+
+          vulns=$(jq -c 'select(.type == "auditSummary") | .data.vulnerabilities' audit.jsonl | tail -1)
+
+          if [ -z "$vulns" ]; then
+            echo "::error::yarn audit no se completó: no hay auditSummary. No se auditó ninguna dependencia."
+            tail -5 audit.jsonl
+            exit 1
+          fi
+
+          echo "Resumen: $vulns"
+          high=$(echo "$vulns" | jq '.high')
+          critical=$(echo "$vulns" | jq '.critical')
+
           # Se ignora moderate a propósito: summernote no tiene parche upstream,
           # entra por admin-lte y la app nunca lo importa, así que no llega al
           # bundle. Fallar por eso dejaría el build en rojo para siempre.
-          yarn audit || EXIT=$?
-          if [ $(( ${EXIT:-0} & 24 )) -ne 0 ]; then
-            echo "::error::Hay vulnerabilidades high o critical en el árbol de npm"
+          if [ "$high" -gt 0 ] || [ "$critical" -gt 0 ]; then
+            echo "::error::Hay $high high y $critical critical en el árbol de npm"
             exit 1
           fi
+
           echo "Sin vulnerabilidades high ni critical"


### PR DESCRIPTION
Hasta ahora el único workflow era CodeQL, que analiza el código propio pero no
ejecuta nada. Ningún PR verificaba que la suite siguiera pasando, así que los
11 PRs de Dependabot abiertos se mergearían **a ciegas**.

## Qué agrega

Dos jobs, en `push` y en `pull_request` contra `main`:

- **test** — `bundle` + `yarn install --frozen-lockfile`, `bin/rails test` y
  `bin/rails test:system` (headless Chrome, ya viene en el runner). Si algo
  falla, sube `tmp/screenshots/` como artifact.
- **audit** — `bundler-audit check --update` y `yarn audit`.

Las versiones de Ruby y Node salen de `.ruby-version` y `.tool-versions`, así
no hay que mantenerlas en dos lugares.

## Un detalle que costó

El paso de `yarn audit` **no** usa `--level high`, aunque parezca lo obvio.
Yarn 1 no devuelve 0/1 sino un **bitmask** de severidades
(`1` info, `2` low, `4` moderate, `8` high, `16` critical), y `--level` sólo
filtra lo que imprime, no el exit code. Lo probé antes de subirlo:
`yarn audit --level high` devuelve `4` en este repo, o sea que habría dejado el
build en rojo permanente por summernote (moderate, sin parche upstream, no
entra al bundle).

Se chequean los bits de high y critical a mano. Verificado con los 8 valores
posibles: pasa con 0/2/4/6, falla con 8/12/16/20.

## Bonus

También protege el acoplamiento de shakapacker: la gema y el paquete npm tienen
que coincidir por `ensure_consistent_versioning: true`, así que mergear sólo
uno de #77 / #84 ahora **falla en CI** en vez de romper en runtime.

## Nota

El workflow en sí no lo pude ejecutar localmente; se valida al abrir este PR.
Los comandos que corre sí los verifiqué uno por uno en local, y pasan.
