### PR TITLE
Bajar la saturación de la paleta y arreglar alineación de botones

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,3 +1,25 @@
+// ---------------------------------------------------------------------------
+// Paleta
+// ---------------------------------------------------------------------------
+// Se bajan la saturación de los colores de tema de Bootstrap antes de
+// importarlo, así el ajuste vale para botones, links, badges y todo lo que
+// derive de ellos, en vez de parchear clase por clase.
+//
+// Todos verifican contraste AA (>= 4.5) con texto blanco:
+//   verde #1f8159 -> 4.84    azul #3d6b9e -> 5.53    rojo #b5493f -> 5.26
+//
+// De referencia, el `bg-lime` de AdminLTE 3 que se usaba antes (#01ff70) daba
+// 1.35 contra blanco: por eso necesitaba texto oscuro y resultaba estridente.
+$primary: #3d6b9e;
+$success: #1f8159;
+$danger: #b5493f;
+$info: #4a7f96;
+$warning: #b5822e;
+
+// Color de las acciones de alta ("add", "New Note", "Sign Up").
+$rn-accent: $success;
+$rn-accent-hover: #196e4b;
+
 // Bootstrap 5 se importa una sola vez acá. Antes lo importaban tanto este
 // archivo como css/styles.scss, así que se compilaba dos veces en el mismo
 // bundle; ese archivo se fusionó acá abajo.
@@ -9,11 +31,46 @@
 
 @import "@fortawesome/fontawesome-free";
 
-// AdminLTE 4 eliminó los helpers de color de la v3. `bg-lime` se usa en los
-// botones de alta, así que se redefine con el mismo valor que tenía la v3.
-.bg-lime {
-  background-color: #01ff70 !important;
-  color: #1f2d3d !important;
+// Acento para las acciones de alta. Reemplaza al `bg-lime` de AdminLTE 3, que
+// la v4 eliminó y que además era un verde neón.
+.bg-accent {
+  background-color: $rn-accent !important;
+  color: #fff !important;
+
+  &:hover,
+  &:focus {
+    background-color: $rn-accent-hover !important;
+    color: #fff !important;
+  }
+}
+
+// Los botones con ícono arriba y texto abajo (home) o ícono al lado del texto
+// (sidebar) necesitan que el contenido se centre de verdad: `.btn` alinea con
+// `text-align`, que no alcanza cuando hay varios elementos en bloque.
+.btn-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  h6 {
+    margin: 0;
+  }
+}
+
+.btn-inline-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+// Ancho de lectura cómodo para los formularios de una sola columna (login,
+// registro, recupero de contraseña).
+.form-narrow {
+  width: 100%;
+  max-width: 26rem;
 }
 
 // ---------------------------------------------------------------------------
@@ -64,5 +121,17 @@
     width: auto;
     vertical-align: middle;
     margin-right: 0.5em;
+  }
+}
+
+// `f.submit` genera un <input type="submit"> sin clases, así que en todos los
+// formularios (Devise, notas, libros) salía con el botón nativo del navegador.
+// Se le da el estilo desde acá para no tener que tocar cada vista.
+.actions {
+  @extend .margin-top;
+
+  input[type='submit'] {
+    @extend .btn;
+    @extend .btn-primary;
   }
 }

--- a/app/views/base/_sidebar.html.erb
+++ b/app/views/base/_sidebar.html.erb
@@ -31,7 +31,7 @@
               with font-awesome or any other icon font library -->
         <%if user_signed_in?%>
           <li class="nav-item">
-            <%= link_to(new_note_path, class:"nav-link bg-lime") do %>
+            <%= link_to(new_note_path, class:"nav-link bg-accent") do %>
               <i class="nav-icon fas fa-plus"></i>
               <p>
                 New Note
@@ -58,7 +58,7 @@
             <%end%>
             <ul class="nav nav-treeview">
               <li class="nav-item">
-                <%= link_to(new_book_path, class:"nav-link bg-lime") do %>
+                <%= link_to(new_book_path, class:"nav-link bg-accent") do %>
                   <i class="nav-icon fas fa-book-medical"></i>
                   <p>
                     New Book
@@ -85,15 +85,18 @@
             </ul>
           </li>
         <%else%> <!-- /.if user_signed_in? -->
+          <%# Estos son botones, no ítems de menú: `nav-icon` les fija un ancho
+              y un alineado pensados para el sidebar y descolocaba el ícono
+              respecto del texto. Se centra con flex. %>
           <li class="nav-item px-3">
             <%# BS5 eliminó .btn-block: se usa w-100. %>
-            <%= link_to(new_user_session_path, class:"btn w-100 bg-primary text-white") do %>
-              <i class="nav-icon fas fa-sign-in-alt"></i> Login
+            <%= link_to(new_user_session_path, class:"btn btn-primary btn-inline-icon w-100") do %>
+              <i class="fas fa-sign-in-alt"></i> Login
             <%end%>
           </li>
           <li class="nav-item mt-2 px-3">
-            <%= link_to(new_user_registration_path, class:"btn w-100 bg-lime") do %>
-              <i class="nav-icon fas fa-user-plus"></i> Sign Up
+            <%= link_to(new_user_registration_path, class:"btn btn-inline-icon w-100 bg-accent") do %>
+              <i class="fas fa-user-plus"></i> Sign Up
             <%end%>
           </li>
         <%end%> <!-- /.if user_signed_in? -->

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -6,7 +6,7 @@
       </div><!-- /.col -->
       <div class="col-sm-6">
         <div class="float-sm-end">
-          <%= link_to(new_book_path, class:"btn bg-lime", title:"Add a new book") do %>
+          <%= link_to(new_book_path, class:"btn bg-accent", title:"Add a new book") do %>
             <i class="fas fa-plus"></i> add
           <%end%>
         </div><!-- /.float -->

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div class="container-fluid">
-  <div class="small-container center-block container-fluid">
+  <div class="form-narrow">
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div class="container-fluid">
-  <div class="container-fluid">
+  <div class="form-narrow">
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="field">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,47 +15,47 @@
 
 <div class="container-fluid">
   <div class="container-fluid">
-    <div class="row d-flex justify-content-center text-center">
+    <div class="row g-3 justify-content-center text-center">
       <% if user_signed_in? %>
-        <div class="col-6 col-sm-4 col-md-3 col-lg-2 m-2">
-          <%= link_to(books_path, class:"btn btn-lg btn-dark") do %>
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+          <%= link_to(books_path, class:"btn btn-lg btn-stack w-100 h-100 py-4 btn-dark") do %>
             <i class="fa-3x fas fa-book"></i>
             <h6 class="mt-2">Books</h6>
           <%end%>
         </div>
-        <div class="col-6 col-sm-4 col-md-3 col-lg-2 m-2">
-          <%= link_to(new_book_path, class:"btn btn-lg bg-lime") do %>
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+          <%= link_to(new_book_path, class:"btn btn-lg btn-stack w-100 h-100 py-4 bg-accent") do %>
             <i class="fa-3x fas fa-book-medical"></i>
             <h6 class="mt-2">Add Book</h6>
           <%end%>
         </div>
-        <div class="col-6 col-sm-4 col-md-3 col-lg-2 m-2">
-          <%= link_to(notes_path, class:"btn btn-lg btn-dark") do %>
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+          <%= link_to(notes_path, class:"btn btn-lg btn-stack w-100 h-100 py-4 btn-dark") do %>
             <i class="fa-3x fas fa-file-alt"></i>
             <h6 class="mt-2">Notes</h6>
           <%end%>
         </div>
-        <div class="col-6 col-sm-4 col-md-3 col-lg-2 m-2">
-          <%= link_to(new_note_path, class:"btn btn-lg bg-lime") do %>
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+          <%= link_to(new_note_path, class:"btn btn-lg btn-stack w-100 h-100 py-4 bg-accent") do %>
             <i class="fa-3x fas fa-file-medical"></i>
             <h6 class="mt-2">Add Note</h6>
           <%end%>
         </div>
-        <div class="col-6 col-sm-4 col-md-3 col-lg-2 m-2">
-          <%= link_to(notes_download_all_path, class:"btn btn-lg btn-primary") do %>
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+          <%= link_to(notes_download_all_path, class:"btn btn-lg btn-stack w-100 h-100 py-4 btn-primary") do %>
             <i class="fa-3x fas fa-file-download"></i>
             <h6 class="mt-2">Export All</h6>
           <%end%>
         </div>
       <%else%>
-        <div class="col-6 col-sm-4 col-md-3 col-lg-2 m-2">
-          <%= link_to(new_user_session_path, class:"btn btn-lg btn-primary") do %>
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+          <%= link_to(new_user_session_path, class:"btn btn-lg btn-stack w-100 h-100 py-4 btn-primary") do %>
             <i class="fa-3x fas fa-sign-in-alt"></i>
             <h6 class="mt-2">Login</h6>
           <%end%>
         </div>
-        <div class="col-6 col-sm-4 col-md-3 col-lg-2 m-2">
-          <%= link_to(new_user_registration_path, class:"btn btn-lg bg-lime") do %>
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+          <%= link_to(new_user_registration_path, class:"btn btn-lg btn-stack w-100 h-100 py-4 bg-accent") do %>
             <i class="fa-3x fas fa-user-plus"></i>
             <h6 class="mt-2">Sign up</h6>
           <%end%>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -6,7 +6,7 @@
       </div><!-- /.col -->
       <div class="col-sm-6">
         <div class="float-sm-end">
-          <%= link_to(new_note_path, class:"btn bg-lime") do %>
+          <%= link_to(new_note_path, class:"btn bg-accent") do %>
             <i class="fas fa-plus"></i> add
           <%end%>
           <%= link_to(notes_download_all_path, class:"btn bg-primary", 


### PR DESCRIPTION
Tres ajustes puntuales sobre la UI, sin rediseñar nada.

## Colores estridentes

El acento venía del `bg-lime` de AdminLTE 3 (`#01ff70`), un verde neón. Medido:

| color | contraste con texto blanco |
|---|---|
| `#01ff70` (el que estaba) | **1.35** |
| `#1f8159` verde (nuevo) | 4.84 |
| `#3d6b9e` azul (nuevo) | 5.53 |
| `#b5493f` rojo (nuevo) | 5.26 |

Con 1.35 el verde no admitía texto blanco — por eso llevaba texto oscuro
encima y resultaba chillón. Los tres nuevos cumplen AA (≥ 4.5) para texto
normal.

Los colores se redefinen **antes** de importar Bootstrap, así el ajuste
alcanza a botones, links y badges de una sola vez en lugar de parchear clase
por clase. `bg-lime` pasa a `bg-accent`, que además dice para qué está.

## Botones mal centrados

Eran dos casos distintos:

- **Sidebar**: los botones de Login y Sign Up usaban `nav-icon`, una clase
  pensada para ítems de menú que les fija ancho y alineado propios, así que el
  ícono quedaba descolgado del texto.
- **Home**: cada tile medía lo que medía su texto, por eso la fila salía
  despareja ("Books" más angosto que "Add Book"). Ahora todos miden igual.

## Login demasiado ancho

El formulario ocupaba todo el ancho del área de contenido, con los inputs de
punta a punta. Se acota a 26rem. `registrations/new` ya se limitaba con
`small-container center-block`; se unifican los dos en `form-narrow`.

## De paso

`f.submit` genera un `<input type="submit">` sin clases, así que en Devise y en
los formularios de notas y libros el botón de envío salía con el estilo nativo
del navegador. Se le da estilo desde `.actions`, sin tocar cada vista.

## Verificación

Capturas de home, login y listado de notas antes y después, más 18 tests
unitarios, 8 de sistema y `assets:precompile`.
