### PR TITLE
Pulir formularios, botoneras, páginas de error y pie

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -73,6 +73,40 @@ $rn-accent-hover: #196e4b;
   max-width: 26rem;
 }
 
+// Los formularios de notas y libros llevan un editor Trix, así que necesitan
+// más ancho que los de Devise, pero tampoco los 1000+ px del área completa.
+.form-wide {
+  width: 100%;
+  max-width: 52rem;
+}
+
+// Avatar del sidebar: la inicial del mail dentro de un círculo, en lugar de la
+// foto de ejemplo que traía la plantilla.
+.user-initial {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 2.125rem;
+  height: 2.125rem;
+  border-radius: 50%;
+  background-color: $rn-accent;
+  color: #fff;
+  font-weight: 600;
+  line-height: 1;
+}
+
+// Separador entre grupos de botones, en reemplazo del carácter "|" que estaba
+// suelto en el markup de las vistas `show`.
+.btn-group-divider {
+  display: inline-block;
+  width: 1px;
+  height: 1.25rem;
+  margin: 0 0.5rem;
+  vertical-align: middle;
+  background-color: var(--bs-border-color);
+}
+
 // ---------------------------------------------------------------------------
 // Clases propias del proyecto (antes en app/javascript/css/styles.scss)
 // ---------------------------------------------------------------------------
@@ -130,8 +164,22 @@ $rn-accent-hover: #196e4b;
 .actions {
   @extend .margin-top;
 
+  // El botón de envío y el de cancelar van en la misma fila y a la misma
+  // escala. Antes el "Cancel" vivía fuera del form y caía en un renglón
+  // aparte, más chico y con otro estilo.
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+
   input[type='submit'] {
     @extend .btn;
     @extend .btn-primary;
   }
+}
+
+// El <select> de `collection_select` no recibe clases, así que quedaba con el
+// desplegable nativo al lado de campos ya estilados.
+.field select {
+  @extend .form-select;
 }

--- a/app/views/base/_footer.html.erb
+++ b/app/views/base/_footer.html.erb
@@ -1,9 +1,12 @@
-<!-- Main Footer -->
+<%# El pie traía el texto de ejemplo de la plantilla ("Copyright 2014-2019
+    AdminLTE.io" y "Anything you want"). Se reemplaza por la identidad del
+    proyecto. No se deja crédito a AdminLTE porque su licencia es MIT y no
+    exige atribución en la interfaz; la licencia sí viaja en node_modules. %>
 <footer class="app-footer">
-  <!-- To the right -->
   <div class="float-end d-none d-sm-inline">
-    Anything you want
+    <%= link_to "Código fuente", "https://github.com/juanpsm/rn",
+        class: "link-secondary", target: "_blank", rel: "noopener" %>
   </div>
-  <!-- Default to the left -->
-  <strong>Copyright &copy; 2014-2019 <a href="https://adminlte.io">AdminLTE.io</a>.</strong> All rights reserved.
+  <strong>RubyNotes</strong>
+  <span class="text-secondary">— gestor de notas</span>
 </footer>

--- a/app/views/base/_sidebar.html.erb
+++ b/app/views/base/_sidebar.html.erb
@@ -16,9 +16,17 @@
       <!-- Sidebar user panel (optional) -->
       <%# .user-panel / .image / .info no existen en v4: se arma con utilidades
           de Bootstrap. %>
+      <%# Antes se mostraba la foto de ejemplo de AdminLTE, la misma persona
+          para todos los usuarios. Se reemplaza por la inicial del mail: no
+          finge una identidad, no pide una dependencia externa y distingue una
+          cuenta de otra. %>
       <div class="d-flex align-items-center gap-2 mt-3 pb-3 mb-3 px-3">
-        <%= image_tag "user2-160x160.jpg", class:"rounded-circle shadow-sm", alt:"User Image", width: 34 %>
-        <a href="#" class="d-block text-decoration-none"><%= current_user.email %></a>
+        <span class="user-initial" aria-hidden="true"><%= current_user.email.first.upcase %></span>
+        <%# `text-body-emphasis` es necesario: el <span> heredaría el color del
+            body (tema claro) y quedaría casi negro sobre el sidebar oscuro.
+            El `data-bs-theme` del aside redefine variables, pero no aplica
+            `color` por sí solo. %>
+        <span class="text-truncate text-body-emphasis" title="<%= current_user.email %>"><%= current_user.email %></span>
       </div>
     <%end%> <!-- /.if user_signed_in? -->
 

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -16,7 +16,9 @@
     <%= form.text_field :name %>
   </div>
 
+  <%# Igual que en notes/_form: el botón de volver va en la misma fila. %>
   <div class="actions">
     <%= form.submit %>
+    <%= link_to cancel_label, cancel_path, class: "btn btn-outline-secondary" %>
   </div>
 <% end %>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -16,10 +16,8 @@
 </div>
 
 <div class="container-fluid">
-  <div class="container-fluid">
+  <div class="form-wide">
 
-    <%= render 'form', book: @book %>
-
-    <%= link_to 'Back', books_path, class:"btn btn-sm btn-outline-secondary" %>
+    <%= render 'form', book: @book, cancel_path: books_path, cancel_label: 'Cancel' %>
   </div>
 </div>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -16,10 +16,8 @@
 </div>
 
 <div class="container-fluid">
-  <div class="container-fluid">
+  <div class="form-wide">
 
-    <%= render 'form', book: @book %>
-
-    <%= link_to 'Back', books_path, class:"btn btn-sm btn-outline-secondary" %>
+    <%= render 'form', book: @book, cancel_path: books_path, cancel_label: 'Back' %>
   </div>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -37,11 +37,11 @@
           title:"Download ALL notes from this book in ONE file.") do %>
         <i class="fas fa-download"></i>
       <%end%>
-      |
+      <span class="btn-group-divider"></span>
       <%= link_to 'Back', books_path, class:"btn btn-sm btn-outline-secondary" %>
     </div>
     <p>
-      <%= @book.notes.size %> notes
+      <%= pluralize(@book.notes.size, "note") %>
     </p>
     <div class="row">
       <% unless @book.notes.blank? %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,8 +1,28 @@
-<div class="text-center">
-  <div>
-    <h1>There was a problem with your request.</h1>
-    <i class="fa-8x fas fa-exclamation-circle text-danger"></i>
-    <h4 class="mt-2">500 Internal Server Error</h4>
-    <p class="mt-2">Don't worry, it's not your fault.</p>
+<%# Las páginas de error usan la misma estructura que el resto: barra de
+    título arriba y contenido debajo. Antes tenían el h1 suelto y centrado,
+    con un ícono fa-8x que se comía la pantalla. %>
+<div class="app-content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <h1 class="m-0 text-body-emphasis">500</h1>
+      </div><!-- /.col -->
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-end">
+          <li class="breadcrumb-item"><%= link_to 'Home', root_path %></li>
+          <li class="breadcrumb-item active">500</li>
+        </ol>
+      </div><!-- /.col -->
+    </div><!-- /.row -->
+  </div><!-- /.container-fluid -->
+</div>
+
+<div class="container-fluid">
+  <div class="d-flex align-items-center gap-3 py-4">
+    <i class="fas fa-exclamation-circle fa-3x text-danger" aria-hidden="true"></i>
+    <div>
+      <h2 class="h4 mb-1">There was a problem with your request.</h2>
+      <p class="mb-0 text-secondary">Don't worry, it's not your fault.</p>
+    </div>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,8 +1,28 @@
-<div class="text-center">
-  <div>
-    <h1>The page you were looking for doesn't exist.</h1>
-    <i class="fa-8x fas fa-exclamation-triangle text-warning"></i>
-    <h4 class="mt-2">404 Not Found</h4>
-    <p class="mt-2">You may have mistyped the address or the page may have moved.</p>
+<%# Las páginas de error usan la misma estructura que el resto: barra de
+    título arriba y contenido debajo. Antes tenían el h1 suelto y centrado,
+    con un ícono fa-8x que se comía la pantalla. %>
+<div class="app-content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <h1 class="m-0 text-body-emphasis">404</h1>
+      </div><!-- /.col -->
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-end">
+          <li class="breadcrumb-item"><%= link_to 'Home', root_path %></li>
+          <li class="breadcrumb-item active">404</li>
+        </ol>
+      </div><!-- /.col -->
+    </div><!-- /.row -->
+  </div><!-- /.container-fluid -->
+</div>
+
+<div class="container-fluid">
+  <div class="d-flex align-items-center gap-3 py-4">
+    <i class="fas fa-exclamation-triangle fa-3x text-warning" aria-hidden="true"></i>
+    <div>
+      <h2 class="h4 mb-1">The page you were looking for doesn't exist.</h2>
+      <p class="mb-0 text-secondary">You may have mistyped the address or the page may have moved.</p>
+    </div>
   </div>
 </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,8 +1,28 @@
-<div class="text-center">
-  <div>
-    <h1>The change you wanted was rejected.</h1>
-    <i class="fa-8x fas fa-ban text-danger"></i>
-    <h4 class="mt-2">422 Unprocessable Entity</h4>
-    <p class="mt-2">Maybe you tried to change something you didn't have access to.</p>
+<%# Las páginas de error usan la misma estructura que el resto: barra de
+    título arriba y contenido debajo. Antes tenían el h1 suelto y centrado,
+    con un ícono fa-8x que se comía la pantalla. %>
+<div class="app-content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <h1 class="m-0 text-body-emphasis">422</h1>
+      </div><!-- /.col -->
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-end">
+          <li class="breadcrumb-item"><%= link_to 'Home', root_path %></li>
+          <li class="breadcrumb-item active">422</li>
+        </ol>
+      </div><!-- /.col -->
+    </div><!-- /.row -->
+  </div><!-- /.container-fluid -->
+</div>
+
+<div class="container-fluid">
+  <div class="d-flex align-items-center gap-3 py-4">
+    <i class="fas fa-ban fa-3x text-danger" aria-hidden="true"></i>
+    <div>
+      <h2 class="h4 mb-1">The change you wanted was rejected.</h2>
+      <p class="mb-0 text-secondary">Maybe you tried to change something you didn't have access to.</p>
+    </div>
   </div>
 </div>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -26,7 +26,11 @@
     <%=form.rich_text_area :content %>
   </div>
 
+  <%# El botón de volver se rinde acá adentro para que quede en la misma fila
+      que el de envío. Antes vivía en new/edit, después del form, y caía en un
+      renglón aparte con otro tamaño. %>
   <div class="actions">
     <%= form.submit %>
+    <%= link_to cancel_label, cancel_path, class: "btn btn-outline-secondary" %>
   </div>
 <% end %>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -2,13 +2,13 @@
   <div class="container-fluid">
     <div class="row mb-2">
       <div class="col-sm-6">
-        <h1 class="m-0 text-body-emphasis">Editing Note <%= @note.id %></h1>
+        <h1 class="m-0 text-body-emphasis">Editing <%= @note.title %></h1>
       </div><!-- /.col -->
       <div class="col-sm-6">
           <ol class="breadcrumb float-sm-end">
             <li class="breadcrumb-item">Home</li>
             <li class="breadcrumb-item"><%= link_to 'notes', notes_path %></li>
-            <li class="breadcrumb-item active">new</li>
+            <li class="breadcrumb-item active">edit</li>
           </ol>
       </div><!-- /.col -->
     </div><!-- /.row -->
@@ -16,8 +16,7 @@
 </div>
 
 <div class="container-fluid">
-  <div class="container-fluid">
-    <%= render 'form', note: @note %>
-    <%= link_to 'Cancel', notes_path, class:"btn btn-sm btn-outline-secondary" %>
+  <div class="form-wide">
+    <%= render 'form', note: @note, cancel_path: notes_path, cancel_label: 'Cancel' %>
   </div>
 </div>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -16,10 +16,8 @@
 </div>
 
 <div class="container-fluid">
-  <div class="container-fluid">
+  <div class="form-wide">
 
-    <%= render 'form', note: @note %>
-
-    <%= link_to 'Back', notes_path, class:"btn btn-sm btn-outline-secondary" %>
+    <%= render 'form', note: @note, cancel_path: notes_path, cancel_label: 'Back' %>
   </div>
 </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -31,10 +31,12 @@
         <div class="card-body">
             <%= @note.content %>
         </div>
+        <%# Antes se imprimía el timestamp crudo con zona ("2026-07-28 03:45:55
+            UTC"), que además no coincidía con el "hace un rato" del listado. %>
         <div class="card-footer small text-muted text-end p-1">
-            created: <%= @note.created_at %>
-            <% if @note.updated_at%>
-              | updated: <%= @note.updated_at %>
+            creada el <%= l @note.created_at, format: :long %>
+            <% if @note.updated_at && @note.updated_at != @note.created_at %>
+              &middot; editada <%= time_ago_in_words @note.updated_at %> atrás
             <% end %>
         </div>
       </div>
@@ -58,7 +60,7 @@
               title: 'Delete note', 'data-bs-toggle' => 'tooltip', 'data-bs-placement' => 'bottom') do %>
             <i class="far fa-trash-alt"></i>
           <%end%>
-          |
+          <span class="btn-group-divider"></span>
           <%= link_to 'Back', notes_path, class:"btn btn-sm btn-outline-secondary" %>
         </div>
       <%end%>

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -4,17 +4,20 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
   test "should get not_found" do
     get my_not_found_url
     assert_response :not_found
-    assert_select "h1", text: "The page you were looking for doesn't exist."
+    assert_select "h1", text: "404"
+    assert_select "h2", text: "The page you were looking for doesn't exist."
   end
 
   test "should get unprocessable_entity" do
     get my_unprocessable_entity_url
     assert_response :unprocessable_entity
+    assert_select "h1", text: "422"
   end
 
   test "should get internal_server_error" do
     get my_internal_server_error_url
     assert_response :internal_server_error
+    assert_select "h1", text: "500"
   end
 
   # Nota: no se testea acá el ruteo de una URL inexistente porque en el entorno


### PR DESCRIPTION
Segunda pasada sobre la interfaz, después del ajuste de paleta de #90.

## Formularios

- **El `<select>` de "Book" salía con el desplegable nativo del navegador.**
  `collection_select` no recibe clases, así que quedaba chico y pegado a la
  etiqueta, al lado de campos que sí tenían estilo. Se aplica `form-select`
  desde `.field select`, que además cubre cualquier select que se agregue
  después.
- **El botón de volver caía en un renglón aparte**, más chico y con otro
  estilo, porque vivía en `new`/`edit` después del form. Ahora se rinde dentro
  de `.actions` vía un local, en la misma fila y a la misma escala.
- **Ancho**: los formularios de notas y libros pasaban los 1000px. Se acotan a
  52rem, que deja lugar al editor Trix sin estirar los inputs.

## Vistas `show`

- **Había un `|` suelto en el markup** separando los íconos del botón de
  volver. Ahora es un separador de verdad.
- **Las fechas se imprimían crudas** (`2026-07-28 03:45:55 UTC`) y encima no
  coincidían con el "hace un rato" que muestra el listado.

## Páginas de error

No usaban `app-content-header`, así que el título quedaba suelto y centrado y
el ícono `fa-8x` se comía la pantalla. Ahora siguen la misma estructura que el
resto, con el código de estado como título.

## Decisiones que me dejaste tomar

**Pie de página** — traía el texto de ejemplo de la plantilla ("Copyright ©
2014-2019 AdminLTE.io", "Anything you want"). Lo reemplacé por la identidad
del proyecto y un link al repositorio. No dejé atribución a AdminLTE: su
licencia es MIT y no exige crédito en la interfaz.

**Avatar** — se mostraba la foto de ejemplo de AdminLTE, la misma persona para
todos los usuarios. Lo cambié por la inicial del mail en un círculo: no finge
una identidad, no agrega dependencias externas y distingue una cuenta de otra.

## Tres bugs de contenido que se veían mal

- El breadcrumb de editar una nota decía "new".
- El título mostraba el id crudo: "Editing Note 980190962".
- "1 notes" en la vista de libro.

## Un detalle que sólo apareció midiendo

Al pasar el mail del sidebar de `<a>` a `<span>` quedó en `rgb(33,37,41)`
sobre el fondo oscuro: contraste **1.34**, prácticamente invisible. El
`data-bs-theme="dark"` del aside redefine variables pero no aplica `color`, así
que el span heredaba el del tema claro. Con `text-body-emphasis` pasa a
**11.51**.

## Verificación

18 tests unitarios (se actualizaron las aserciones de las páginas de error),
8 de sistema, `assets:precompile` sin errores, y revisión visual de
formularios, `show`, 404 y pie.
