### PR TITLE
Que las páginas de error respondan a peticiones que no son HTML

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,13 +1,34 @@
 class ErrorsController < ApplicationController
   def not_found
-    render status: :not_found
+    render_error :not_found
   end
 
   def unprocessable_entity
-    render status: :unprocessable_entity
+    render_error :unprocessable_entity
   end
 
   def internal_server_error
-    render status: :internal_server_error
+    render_error :internal_server_error
+  end
+
+  private
+
+  # Las excepciones no siempre vienen de una petición HTML: también fallan
+  # pedidos de imágenes, PDFs o JSON. Antes se hacía `render` a secas, así que
+  # ante un error en, por ejemplo, la miniatura de un avatar, Rails buscaba
+  # `errors/internal_server_error.png`, no lo encontraba y la propia página de
+  # error explotaba:
+  #
+  #   Error during failsafe response: Missing template
+  #   errors/internal_server_error with {:formats=>[:png]}
+  #
+  # Para formatos sin plantilla se devuelve el estado pelado, que es lo que un
+  # <img> o un fetch pueden manejar.
+  def render_error(status)
+    respond_to do |format|
+      format.html { render status: status }
+      format.json { render json: { error: status.to_s }, status: status }
+      format.any { head status }
+    end
   end
 end

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -20,6 +20,26 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", text: "500"
   end
 
+  # Las excepciones también salen de peticiones que no son HTML: la miniatura
+  # de un avatar, un PDF, un fetch. Antes, para esos formatos, no había
+  # plantilla y fallaba el render de la propia página de error:
+  #   "Error during failsafe response: Missing template ... {:formats=>[:png]}"
+  test "responds to non-HTML requests without blowing up" do
+    get my_internal_server_error_url(format: :png)
+    assert_response :internal_server_error
+    assert_empty response.body
+
+    get my_not_found_url(format: :pdf)
+    assert_response :not_found
+  end
+
+  test "responds to JSON requests with a JSON body" do
+    get my_not_found_url(format: :json)
+
+    assert_response :not_found
+    assert_equal "not_found", response.parsed_body["error"]
+  end
+
   # Nota: no se testea acá el ruteo de una URL inexistente porque en el entorno
   # de test `consider_all_requests_local` es true y DebugExceptions muestra su
   # propia página antes de delegar en `exceptions_app`. En producción, con


### PR DESCRIPTION
Este commit quedó afuera de #92: lo pusheé unos minutos después del merge.

## El problema

Apareció en los logs de un fallo al generar la miniatura de un avatar. La
petición del `<img>` reventó y, al intentar mostrar la página de error, reventó
otra vez:

```
Error during failsafe response: Missing template
errors/internal_server_error, application/internal_server_error
with {:formats=>[:png]}
```

Las páginas de error sólo tienen plantilla HTML, pero `exceptions_app` recibe
también pedidos de imágenes, PDFs y JSON. Ante uno de esos, Rails busca
`errors/internal_server_error.png`, no la encuentra, y falla al renderizar la
propia página de error.

O sea que **cualquier fallo en un asset generaba un segundo fallo encima** —
que además tapa el error original en el log y hace más difícil diagnosticarlo,
que es exactamente lo que pasó.

## El arreglo

Se responde según el formato:

| formato | respuesta |
|---|---|
| HTML | la plantilla de siempre |
| JSON | `{"error": "not_found"}` con el status |
| cualquier otro | el status pelado, sin cuerpo |

Lo último es lo que un `<img>` o un `fetch` pueden manejar.

## Verificación

Dos tests de regresión, comprobados en rojo revirtiendo el controlador: fallan
con el mismo `MissingTemplate` que aparece en el log.

```
con el controlador viejo:  5 runs, 2 errors
con el arreglo:            5 runs, 0 errors
```

Suite completa: 35 unitarios + 13 de sistema.

## Cómo probarlo a mano

```bash
curl -i http://localhost:3000/500.png    # 500 limpio, cuerpo vacío
curl -i http://localhost:3000/404.json   # {"error":"not_found"}
```
