### PR TITLE
test: recuperar el test de borrado de libro desde su propia página

### DIFF
--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -43,6 +43,26 @@ class BooksTest < ApplicationSystemTestCase
     assert_selector "h1", text: "Nombre actualizado"
   end
 
+  # Recuperado del PR #74, que arregló este mismo bug el 27/07: el botón usaba
+  # `note_path` sin argumento y el helper completaba el :id con el del request,
+  # así que desde /books/42 mandaba un DELETE a /notes/42.
+  #
+  # Ese test se perdió en la migración a AdminLTE 4 (785ffda), que reescribió
+  # books/show.html.erb desde la versión previa al arreglo y reintrodujo el
+  # bug. Sin el test, nadie lo notó hasta dos días después.
+  #
+  # El de controlador comprueba el href renderizado; éste hace el click y
+  # verifica que el libro efectivamente desaparezca.
+  test "destroying a Book from its show page" do
+    visit book_url(@book)
+
+    accept_confirm { find("a[aria-label='Delete book']").click }
+
+    assert_text "Book was successfully destroyed"
+    assert_selector "h1", text: "Books"
+    assert_nil Book.find_by(id: @book.id)
+  end
+
   test "destroying a Book" do
     visit books_url
 


### PR DESCRIPTION
El PR #74 arregló el 27/07 el botón "Delete book" de books/show, que usaba
`note_path` sin argumento: el helper completaba el segmento :id con el del
request en curso, así que desde /books/42 mandaba un DELETE a /notes/42. Ese
PR agregó dos tests de regresión.

Ninguno de los dos llegó a main, y tampoco el arreglo. La causa es la base
del PR:

    #73  base=main                              merged 20:35:14Z
    #74  base=chore/upgrade-ruby-3.2-rails-7.2  merged 20:35:31Z

#74 apuntaba a la rama del upgrade en vez de a main, y se mergeó 17 segundos
después de que esa rama ya hubiera sido integrada por el #73. Su merge commit
(53b04fa) quedó colgado de una rama muerta; hoy sigue ahí, como los "2 commits
ahead" que GitHub le muestra a esa rama.

Así que books/show.html.erb en main nunca tuvo el arreglo. La migración a
AdminLTE 4 no lo revirtió: heredó el estado que ya estaba. El bug estuvo vivo
hasta c38a375, que lo arregló de nuevo junto con un test de controlador sobre
el href renderizado.

Faltaba el de sistema, que es el que hace el click de verdad y comprueba que
el libro desaparezca; se recupera acá, adaptado al markup nuevo (los botones
se ubican por aria-label, porque el tooltip de Bootstrap les saca el title al
inicializarse).

Verificado en rojo reintroduciendo `note_path` en la vista: fallan los dos,
el de sistema y el de controlador.

